### PR TITLE
feat: immutable values

### DIFF
--- a/src/ImmutableSet.ts
+++ b/src/ImmutableSet.ts
@@ -1,0 +1,78 @@
+export class ImmutableSet<T> implements ReadonlySet<T> {
+  #set: Set<T>;
+
+  constructor(values?: Iterable<T> | null) {
+    this.#set = values instanceof Set ? values : new Set(values);
+  }
+
+  [Symbol.iterator](): SetIterator<T> {
+    return this.#set[Symbol.iterator]();
+  }
+
+  get size(): number {
+    return this.#set.size;
+  }
+
+  has(value: T): boolean {
+    return this.#set.has(value);
+  }
+
+  keys(): SetIterator<T> {
+    return this.#set.keys();
+  }
+
+  values(): SetIterator<T> {
+    return this.#set.values();
+  }
+
+  entries(): SetIterator<[T, T]> {
+    return this.#set.entries();
+  }
+
+  forEach<TSelf>(
+    callbackfn: (value: T, value2: T, set: Set<T>) => void,
+    thisArg?: TSelf,
+  ): void {
+    this.#set.forEach(callbackfn, thisArg);
+  }
+
+  union<U>(other: ReadonlySetLike<U>): Set<T | U> {
+    return this.#set.union(other);
+  }
+
+  intersection<U>(other: ReadonlySet<U>): Set<T & U> {
+    return this.#set.intersection(other);
+  }
+
+  difference<U>(other: ReadonlySet<U>): Set<T> {
+    return this.#set.difference(other);
+  }
+
+  symmetricDifference<U>(other: ReadonlySet<U>): Set<T | U> {
+    return this.#set.symmetricDifference(other);
+  }
+
+  isSubsetOf<U>(other: ReadonlySet<U>): boolean {
+    return this.#set.isSubsetOf(other);
+  }
+
+  isSupersetOf<U>(other: ReadonlySet<U>): boolean {
+    return this.#set.isSupersetOf(other);
+  }
+
+  isDisjointFrom<U>(other: ReadonlySet<U>): boolean {
+    return this.#set.isDisjointFrom(other);
+  }
+
+  get [Symbol.toStringTag](): string {
+    return "ImmutableSet";
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
+    return `ImmutableSet(${this.size}) { ${
+      [...this.#set]
+        .map((value) => Deno.inspect(value, { colors: !Deno.noColor }))
+        .join(", ")
+    } }`;
+  }
+}

--- a/src/MultiDict.ts
+++ b/src/MultiDict.ts
@@ -1,3 +1,5 @@
+import { ImmutableSet } from "./ImmutableSet.ts";
+
 /**
  * A multi-key multi-value map implementation.
  *
@@ -82,8 +84,12 @@ export class MultiDict<K, V>
    */
   get(key: K): ReadonlySet<V> | undefined;
   get(key: V): ReadonlySet<K> | undefined;
-  get(key: K | V) {
-    return this.#map.get(key) as ReadonlySet<K | V> | undefined;
+  get(key: K | V): ReadonlySet<K | V> | undefined {
+    const set = this.#map.get(key);
+
+    if (set) {
+      return new ImmutableSet(set);
+    }
   }
 
   /**
@@ -111,10 +117,8 @@ export class MultiDict<K, V>
   }
 
   #set(key: K | V, value: K | V) {
-    const set = this.#map.get(key) ?? new Set();
-    set.add(value);
-
-    this.#map.set(key, set);
+    this.#map.get(key)?.add(value) ??
+      this.#map.set(key, new Set([value]));
 
     return this;
   }


### PR DESCRIPTION
Returns ImmutableSet instead of Set to prevent accidental value changes.

To prevent unnecessary bloating, this PR will not be merged until requested by users.